### PR TITLE
Remove checkAndroidPermissions (this should be handled by the client …

### DIFF
--- a/src/OT.js
+++ b/src/OT.js
@@ -1,33 +1,8 @@
-import { NativeModules, NativeEventEmitter, PermissionsAndroid } from 'react-native';
+import { NativeModules, NativeEventEmitter } from 'react-native';
 import { each } from 'underscore';
 
 const OT = NativeModules.OTSessionManager;
 const nativeEvents = new NativeEventEmitter(OT);
-
-const checkAndroidPermissions = (checkVideoPermission: boolean) => new Promise((resolve, reject) => {
-  PermissionsAndroid.requestMultiple(
-      [PermissionsAndroid.PERMISSIONS.RECORD_AUDIO]
-        .concat(checkVideoPermission ? [PermissionsAndroid.PERMISSIONS.CAMERA] : [])
-    )
-    .then((result) => {
-      const permissionsError = {};
-      permissionsError.permissionsDenied = [];
-      each(result, (permissionValue, permissionType) => {
-        if (permissionValue === 'denied') {
-          permissionsError.permissionsDenied.push(permissionType);
-          permissionsError.type = 'Permissions error';
-        }
-      });
-      if (permissionsError.permissionsDenied.length > 0) {
-        reject(permissionsError);
-      } else {
-        resolve();
-      }
-    })
-    .catch((error) => {
-      reject(error);
-    });
-});
 
 const setNativeEvents = (events) => {
   const eventNames = Object.keys(events);
@@ -59,7 +34,6 @@ const removeNativeEvents = (events) => {
 export {
   OT,
   nativeEvents,
-  checkAndroidPermissions,
   setNativeEvents,
   removeNativeEvents,
 };

--- a/src/OTPublisher.js
+++ b/src/OTPublisher.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { View, Platform } from 'react-native';
 import { isNull } from 'underscore';
 import {
-  checkAndroidPermissions,
   OT,
   removeNativeEvents,
   nativeEvents,
@@ -98,17 +97,7 @@ class OTPublisher extends Component {
     }
   };
   createPublisher() {
-    if (Platform.OS === 'android') {
-      checkAndroidPermissions(!!this.props.properties?.videoTrack)
-        .then(() => {
-          this.initPublisher();
-        })
-        .catch((error) => {
-          this.otrnEventHandler(error);
-        });
-    } else {
-      this.initPublisher();
-    }
+    this.initPublisher();
   }
   initPublisher() {
     const publisherProperties = sanitizeProperties(this.props.properties);


### PR DESCRIPTION
### Solves issue(s)
Removes permission request UI on Android in favor of doing so in the hosting app. This will give better control over timing, text, handlers, etc.
